### PR TITLE
Configurator to retrieve current container - closes #26

### DIFF
--- a/src/main/java/io/risotto/annotations/CurrentContainer.java
+++ b/src/main/java/io/risotto/annotations/CurrentContainer.java
@@ -1,0 +1,4 @@
+package io.risotto.annotations;
+
+public @interface CurrentContainer {
+}

--- a/src/main/java/io/risotto/annotations/CurrentContainer.java
+++ b/src/main/java/io/risotto/annotations/CurrentContainer.java
@@ -1,4 +1,20 @@
 package io.risotto.annotations;
 
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Inject specifier annotation that can be used to mark a target to current container instance
+ * injection.
+ * @see io.risotto.configurator.CurrentContainerConfigurator;
+ */
+@InjectSpecifier
+@Target({ANNOTATION_TYPE})
+@Retention(RUNTIME)
+@Documented
 public @interface CurrentContainer {
 }

--- a/src/main/java/io/risotto/annotations/CurrentContainer.java
+++ b/src/main/java/io/risotto/annotations/CurrentContainer.java
@@ -1,6 +1,8 @@
 package io.risotto.annotations;
 
-import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
@@ -13,7 +15,7 @@ import java.lang.annotation.Target;
  * @see io.risotto.configurator.CurrentContainerConfigurator
  */
 @InjectSpecifier
-@Target({ANNOTATION_TYPE})
+@Target({PARAMETER, FIELD, METHOD})
 @Retention(RUNTIME)
 @Documented
 public @interface CurrentContainer {

--- a/src/main/java/io/risotto/annotations/CurrentContainer.java
+++ b/src/main/java/io/risotto/annotations/CurrentContainer.java
@@ -10,7 +10,7 @@ import java.lang.annotation.Target;
 /**
  * Inject specifier annotation that can be used to mark a target to current container instance
  * injection.
- * @see io.risotto.configurator.CurrentContainerConfigurator;
+ * @see io.risotto.configurator.CurrentContainerConfigurator
  */
 @InjectSpecifier
 @Target({ANNOTATION_TYPE})

--- a/src/main/java/io/risotto/configurator/ConfiguratorManager.java
+++ b/src/main/java/io/risotto/configurator/ConfiguratorManager.java
@@ -20,7 +20,8 @@ public class ConfiguratorManager {
       new ArrayList<>();
 
   static {
-    registerDefaultConfigurator(new ChildConfigurator(), new BindingConfigurator());
+    registerDefaultConfigurator(new ChildConfigurator(), new BindingConfigurator(),
+        new CurrentContainerConfigurator());
   }
 
   /**

--- a/src/main/java/io/risotto/configurator/CurrentContainerConfigurator.java
+++ b/src/main/java/io/risotto/configurator/CurrentContainerConfigurator.java
@@ -1,0 +1,12 @@
+package io.risotto.configurator;
+
+import io.risotto.Container;
+import io.risotto.exception.ContainerConfigurationException;
+
+public class CurrentContainerConfigurator implements Configurator {
+  @Override
+  public void configure(Container containerInstance, Class<? extends Container> containerClass)
+      throws ContainerConfigurationException {
+
+  }
+}

--- a/src/main/java/io/risotto/configurator/CurrentContainerConfigurator.java
+++ b/src/main/java/io/risotto/configurator/CurrentContainerConfigurator.java
@@ -21,7 +21,10 @@ public class CurrentContainerConfigurator implements Configurator {
   public void configure(Container containerInstance, Class<? extends Container> containerClass)
       throws ContainerConfigurationException {
     InstantiatableBinding<Container> binding =
-        bind(Container.class).withAnnotation(CurrentContainer.class).toInstance(containerInstance);
+        bind(Container.class)
+            .withAnnotation(CurrentContainer.class)
+            .toInstance(containerInstance)
+            .privateScope();
 
     addToContainer(containerInstance, containerClass, binding);
   }

--- a/src/main/java/io/risotto/configurator/CurrentContainerConfigurator.java
+++ b/src/main/java/io/risotto/configurator/CurrentContainerConfigurator.java
@@ -1,12 +1,45 @@
 package io.risotto.configurator;
 
+import static io.risotto.binding.BasicBinding.bind;
+
 import io.risotto.Container;
+import io.risotto.annotations.CurrentContainer;
+import io.risotto.binding.InstantiatableBinding;
 import io.risotto.exception.ContainerConfigurationException;
 
+import java.lang.reflect.Method;
+
+/**
+ * Configurator that adds a binding wrapping the currently configurated container instance. The
+ * binding is an annotated binding using the {@link io.risotto.annotations.CurrentContainer}
+ * annotation.
+ */
 public class CurrentContainerConfigurator implements Configurator {
+  private static final String ADD_BINDING_METHOD_NAME = "addBinding";
+
   @Override
   public void configure(Container containerInstance, Class<? extends Container> containerClass)
       throws ContainerConfigurationException {
+    InstantiatableBinding<Container> binding =
+        bind(Container.class).withAnnotation(CurrentContainer.class).toInstance(containerInstance);
 
+    addToContainer(containerInstance, containerClass, binding);
+  }
+
+  private void addToContainer(Container container, Class<? extends Container> containerClass,
+                              InstantiatableBinding<?> binding)
+      throws ContainerConfigurationException {
+    try {
+      Class<?> superClass = containerClass.getSuperclass();
+
+      Method addBindingMethod =
+          superClass.getDeclaredMethod(ADD_BINDING_METHOD_NAME, InstantiatableBinding.class);
+
+      addBindingMethod.setAccessible(true);
+
+      addBindingMethod.invoke(container, binding);
+    } catch (SecurityException | IllegalArgumentException | ReflectiveOperationException e) {
+      throw new ContainerConfigurationException(container, e);
+    }
   }
 }


### PR DESCRIPTION
The `CurrentContainer` annotation were added to prevent the binding from colliding with user-defined bindings.
